### PR TITLE
Revert bot consolidation

### DIFF
--- a/legacy_music_bot.py
+++ b/legacy_music_bot.py
@@ -48,8 +48,11 @@ class Config:
     discord_token = "YOUR_TOKEN_HERE"
     default_volume = 0.5
     auto_disconnect_delay = 300
-   ugt = "YOUR_FFMPEG_EXECUTABLE_PATH"
-    ffmpeg_options = {'before_options': '-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5', 'options': '-vn'}
+    ffmpeg_executable = "YOUR_FFMPEG_EXECUTABLE_PATH"
+    ffmpeg_options = {
+        'before_options': '-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5',
+        'options': '-vn'
+    }
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- revert changes that added consolidated bot runner and documentation
- restore indentation fix in `legacy_music_bot.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686aaa7859948320bdcf00f760716c71